### PR TITLE
fix(parser): allow detection of compilers prefixed with path

### DIFF
--- a/ccdgen/__main__.py
+++ b/ccdgen/__main__.py
@@ -165,7 +165,7 @@ def detect_compiler(line: str) -> str | None:
 
     for token in line.split(' '):
         for compiler in COMPILERS:
-            if token == compiler or token[:-len(compiler)] == compiler:
+            if token[-len(compiler):] == compiler:
                 print(f'Detected compiler: {token}')
                 return token
 


### PR DESCRIPTION
## Description

- Fixed an issue where compilers prefixed with a path (e.g. `/usr/bin/clang++`) were not detected due to incorrect string slicing.

Fixes #4 

## Checklist

- [x] Generation of compile commands database for test project succeeds
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)