### PR TITLE
fix(parser): disable `--dry-run` on Windows to capture stdout

### DIFF
--- a/ccdgen/__main__.py
+++ b/ccdgen/__main__.py
@@ -74,8 +74,15 @@ def make(command: list[str] = []) -> str:
 
     CODEC = 'utf-8' # TODO: is this always the case?
 
+
+    # dry run broke make's output on windows, so isn't used, but is on others
+    if sys.platform == "win32":
+        make_commands = ['-B'] 
+    else:
+        make_commands = ['-B', '--dry-run']
+
     try:
-        result = subprocess.run(command + ['-B', '--dry-run'], 
+        result = subprocess.run(command + make_output, 
                                 stdout=subprocess.PIPE, 
                                 stderr=subprocess.PIPE)
         ret = None

--- a/ccdgen/__main__.py
+++ b/ccdgen/__main__.py
@@ -82,7 +82,7 @@ def make(command: list[str] = []) -> str:
         make_commands = ['-B', '--dry-run']
 
     try:
-        result = subprocess.run(command + make_output, 
+        result = subprocess.run(command + make_commands, 
                                 stdout=subprocess.PIPE, 
                                 stderr=subprocess.PIPE)
         ret = None


### PR DESCRIPTION
## Description
works on windows - make stdout output is captured as expected instead of only getting the first line

- Summary of changes
- doesn't use the --dry-run flag on windows, but should still use it on other platforms