### PR TITLE
fix: re-enable `--dry-run` on Windows

### DIFF
--- a/ccdgen/__main__.py
+++ b/ccdgen/__main__.py
@@ -74,11 +74,7 @@ def make(command: list[str] = []) -> str:
 
     CODEC = 'utf-8' # TODO: is this always the case?
 
-    # dry run doesn't seem to work on windows
-    if sys.platform == "win32":
-        make_commands = ['--always-make'] 
-    else:
-        make_commands = ['--always-make', '--dry-run']
+    make_commands = ['--always-make', '--dry-run']
 
     try:
         result = subprocess.run(command + make_commands, 


### PR DESCRIPTION
## Description

- Re-enables `--dry-run` on Windows.

## Checklist

- [x] Generation of compile commands database for test project succeeds
- [ ] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)