### PR TITLE
fix: replacement of include paths

### DIFF
--- a/ccdgen/__main__.py
+++ b/ccdgen/__main__.py
@@ -167,12 +167,16 @@ def replace_relative_paths(command: str) -> str:
         Command with relative paths replaced
     """
 
+    # capture does not include the -I
     matches = re.findall(r'-I([^\s]+)', command)
 
     for m in matches:
-        relative_path = m # capture does not include the -I
+        # space in replacement ensures that include paths which are a subset of
+        # another include path are not replaced in that path
+        # TODO: regex replace might remove need for this^
+        relative_path = m
         absolute_path = os.path.abspath(relative_path)
-        command = command.replace(m, absolute_path)
+        command = command.replace(m + ' ', absolute_path + ' ')
     
     return command
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@ BUILD_DIR = build
 
 C_SOURCES = src/test.c src/foo/foo.c
 C_FLAGS = -Wall -Werror -std=c11 -O3
-C_INCLUDES = -Isrc/foo
+C_INCLUDES = -Isrc/foo -Isrc/bar
 CC = gcc
 EXE = $(BUILD_DIR)/test
 

--- a/test/src/bar/bar.h
+++ b/test/src/bar/bar.h
@@ -1,0 +1,1 @@
+#define BAR

--- a/test/src/foo/foo.c
+++ b/test/src/foo/foo.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include "bar.h"
 
 void foo()
 {


### PR DESCRIPTION
## Description

- Include paths which are a subset of another include path (e.g. `inc/foo` to `inc/foo/bar`) are now replaced with the absolute path correctly.

## Checklist

- [x] Generation of compile commands database for test project succeeds
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)